### PR TITLE
Add Status to ResourceInfo

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -109,6 +109,9 @@ message ResourceInfo {
   // OPTIONAL.
   // StorageSpace where this resource is located.
   StorageSpace space = 19;
+  // OPTIONAL
+  // Status of the resource
+  Status string = 20;
 }
 
 // CanonicalMetadata contains extra metadata


### PR DESCRIPTION
Adds a `Status` field to the resource info of a resource. This field can be used to signal a meta status of the resource (like "processing", "readytouse", "blocked", ...). For backwards compatibility an empty status should be considered as "ok"