### PR TITLE
feat: add description field to drive object

### DIFF
--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -476,6 +476,8 @@ message StorageSpace {
   // OPTIONAL.
   // HasTrashedItems indicates if the storage space has trashed items.
   bool has_trashed_items = 10;
+  // OPTIONAL.
+  string description = 11;
 }
 
 // The id of a storage space.


### PR DESCRIPTION
This PR adds an optional `description` property to the `StorageSpace` type.

This is used to populate spaces' subtitles/descriptions.