### PR TITLE
Add new filter type for Spaceroots to share requests

### DIFF
--- a/cs3/sharing/collaboration/v1beta1/resources.proto
+++ b/cs3/sharing/collaboration/v1beta1/resources.proto
@@ -194,6 +194,10 @@ message Filter {
     TYPE_SPACE_ID = 7;
     TYPE_STATE = 8;
     TYPE_GRANTEE = 9;
+    // Filter shares by whether the shared resource is a space root.
+    // When the term `space_root` is true, only shares on space roots are returned.
+    // When false, shares on space roots are excluded.
+    TYPE_SPACE_ROOT = 10;
   }
   // REQUIRED.
   Type type = 2;
@@ -205,5 +209,7 @@ message Filter {
     string space_id = 7;
     ShareState state = 8;
     storage.provider.v1beta1.Grantee grantee = 9;
+    // Used with TYPE_SPACE_ROOT.
+    bool space_root = 10;
   }
 }


### PR DESCRIPTION
This adds a new Filter type for the ListShares request. To be able to only List shares for SpaceRoots (i.e. Space memberships) and to be able to exclude SpaceRoot shares from the result. 