### PR TITLE
OCM: added an optional destination on ReceivedShare

### DIFF
--- a/cs3/sharing/ocm/v1beta1/resources.proto
+++ b/cs3/sharing/ocm/v1beta1/resources.proto
@@ -164,6 +164,10 @@ message ReceivedShare {
   // REQUIRED.
   // Shared resource type.
   cs3.sharing.ocm.v1beta1.SharedResourceType shared_resource_type = 17;
+  // OPTIONAL.
+  // Destination path of the share, in case the shared resource type is EMBEDDED
+  // or the access type is DATATX.
+  string destination = 18;
 }
 
 // The state of the share.


### PR DESCRIPTION
We are adding an optional field to `ocm.ReceivedShare`, for a receiving system when dealing with an OCM share that implies a data transfer: in that case, the flow is for the receiving user to "accept" the share and select a destination path. The extra field would be populated with the given path, so that the backend can execute the data transfer.