### PR TITLE
feat: add container-specific permissions and immutable flag

### DIFF
--- a/cs3/storage/provider/v1beta1/provider_api.proto
+++ b/cs3/storage/provider/v1beta1/provider_api.proto
@@ -172,6 +172,16 @@ service ProviderAPI {
   // or if the caller does not hold the lock.
   // The caller MUST have write permissions on the resource.
   rpc Unlock(UnlockRequest) returns (UnlockResponse);
+  // Sets the immutable (frozen) attribute on a resource.
+  // MUST return CODE_NOT_FOUND if the reference does not exist.
+  // The caller MUST have management permissions on the resource
+  // (space owner, space manager, or administrator).
+  rpc SetImmutable(SetImmutableRequest) returns (SetImmutableResponse);
+  // Removes the immutable (frozen) attribute from a resource.
+  // MUST return CODE_NOT_FOUND if the reference does not exist.
+  // MUST return CODE_FAILED_PRECONDITION if the resource is not immutable.
+  // The caller MUST have management permissions on the resource.
+  rpc UnsetImmutable(UnsetImmutableRequest) returns (UnsetImmutableResponse);
   // Creates the home directory for a user.
   rpc CreateHome(CreateHomeRequest) returns (CreateHomeResponse);
   // Gets the home path for the user.
@@ -1049,6 +1059,42 @@ message UnlockRequest {
 }
 
 message UnlockResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+}
+
+message SetImmutableRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The reference to the resource to freeze.
+  Reference ref = 2;
+}
+
+message SetImmutableResponse {
+  // REQUIRED.
+  // The response status.
+  cs3.rpc.v1beta1.Status status = 1;
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 2;
+}
+
+message UnsetImmutableRequest {
+  // OPTIONAL.
+  // Opaque information.
+  cs3.types.v1beta1.Opaque opaque = 1;
+  // REQUIRED.
+  // The reference to the resource to unfreeze.
+  Reference ref = 2;
+}
+
+message UnsetImmutableResponse {
   // REQUIRED.
   // The response status.
   cs3.rpc.v1beta1.Status status = 1;

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -109,6 +109,15 @@ message ResourceInfo {
   // OPTIONAL.
   // StorageSpace where this resource is located.
   StorageSpace space = 19;
+  // OPTIONAL.
+  // When true, the resource is immutable (frozen). An immutable resource
+  // cannot be modified, deleted, moved or renamed. For containers, immutability
+  // additionally prevents creation of new children (files or sub-containers),
+  // but existing children that are not themselves immutable can still be modified.
+  // Only space managers or administrators can set or clear this flag.
+  // Typical use case: protecting a file plan (Aktenplan) directory structure
+  // or implementing retention/legal hold at the resource level.
+  bool immutable = 20;
 }
 
 // CanonicalMetadata contains extra metadata
@@ -293,6 +302,9 @@ message ResourceId {
 message ResourcePermissions {
   bool add_grant = 1;
   bool create_container = 2;
+  // delete applies to files. For containers, see delete_container.
+  // When delete_container is not explicitly set, implementations
+  // SHOULD fall back to the value of delete for backward compatibility.
   bool delete = 3;
   bool get_path = 5;
   bool get_quota = 6;
@@ -302,6 +314,9 @@ message ResourcePermissions {
   bool list_container = 10;
   bool list_file_versions = 11;
   bool list_recycle = 12;
+  // move applies to files. For containers, see move_container.
+  // When move_container is not explicitly set, implementations
+  // SHOULD fall back to the value of move for backward compatibility.
   bool move = 13;
   bool remove_grant = 14;
   bool purge_recycle = 15;
@@ -310,6 +325,18 @@ message ResourcePermissions {
   bool stat = 18;
   bool update_grant = 19;
   bool deny_grant = 20;
+  // OPTIONAL.
+  // When set, controls whether containers (directories) can be deleted,
+  // independent of the delete permission which then only applies to files.
+  // This allows protecting directory structures while still permitting
+  // file deletion. Typical use case: file plan (Aktenplan) protection.
+  bool delete_container = 21;
+  // OPTIONAL.
+  // When set, controls whether containers (directories) can be
+  // moved or renamed, independent of the move permission which
+  // then only applies to files. This allows protecting directory
+  // structures while still permitting file operations.
+  bool move_container = 22;
 }
 
 // A grant grants permissions

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -110,15 +110,30 @@ message ResourceInfo {
   // StorageSpace where this resource is located.
   StorageSpace space = 19;
   // OPTIONAL.
-  // Indicates whether the resource is immutable (frozen).
-  // An immutable resource cannot be deleted, moved or renamed.
-  // For containers, immutability additionally prevents creation
-  // of new children, but existing non-immutable children can
-  // still be modified.
+  // Indicates whether the resource is immutable.
+  // Its effect depends on the resource type:
+  //
+  // On a file (freeze): the file is final. It cannot be modified
+  // (content is fixed), deleted, moved or renamed. Once set on a
+  // file, the immutable attribute MUST NOT be removed.
+  //
+  // On a container (protect): no entries can be added, removed or
+  // modified. The container itself cannot be deleted, moved or
+  // renamed. This does NOT propagate to the entries: a protected
+  // container can contain unprotected children in which entries
+  // can still be added, removed or modified. The immutable
+  // attribute on a container can be removed by space managers or
+  // administrators.
+  //
+  // An object is considered immutable if its own attribute is set
+  // (self) OR its parent container's attribute is set (parent).
+  // Deletion, modification or renaming of an object is governed
+  // by the parent; adding or removing entries inside a container
+  // by the container itself.
+  //
   // This is a persistent attribute (stored as xattr), not a
-  // transient status. Use SetImmutable/UnsetImmutable RPCs
-  // to change it. Only space managers or administrators
-  // should be allowed to set or clear this attribute.
+  // transient status. Use SetImmutable/UnsetImmutable RPCs to
+  // change it.
   bool immutable = 20;
 }
 

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -110,13 +110,15 @@ message ResourceInfo {
   // StorageSpace where this resource is located.
   StorageSpace space = 19;
   // OPTIONAL.
-  // When true, the resource is immutable (frozen). An immutable resource
-  // cannot be modified, deleted, moved or renamed. For containers, immutability
-  // additionally prevents creation of new children (files or sub-containers),
-  // but existing children that are not themselves immutable can still be modified.
-  // Only space managers or administrators can set or clear this flag.
-  // Typical use case: protecting a file plan (Aktenplan) directory structure
-  // or implementing retention/legal hold at the resource level.
+  // Indicates whether the resource is immutable (frozen).
+  // An immutable resource cannot be deleted, moved or renamed.
+  // For containers, immutability additionally prevents creation
+  // of new children, but existing non-immutable children can
+  // still be modified.
+  // This is a persistent attribute (stored as xattr), not a
+  // transient status. Use SetImmutable/UnsetImmutable RPCs
+  // to change it. Only space managers or administrators
+  // should be allowed to set or clear this attribute.
   bool immutable = 20;
 }
 

--- a/cs3/storage/provider/v1beta1/resources.proto
+++ b/cs3/storage/provider/v1beta1/resources.proto
@@ -354,6 +354,18 @@ message ResourcePermissions {
   // then only applies to files. This allows protecting directory
   // structures while still permitting file operations.
   bool move_container = 22;
+  // OPTIONAL.
+  // Controls whether the user may freeze files (set immutable on files).
+  // Freezing a file is irreversible — once set, the file cannot be
+  // modified, deleted, moved or renamed, and the attribute cannot be
+  // removed. This permission should be granted carefully.
+  bool set_immutable_file = 23;
+  // OPTIONAL.
+  // Controls whether the user may protect or unprotect containers
+  // (set/unset immutable on containers). Protecting a container
+  // prevents adding, removing or modifying its direct entries.
+  // Unlike files, container protection is reversible.
+  bool set_immutable_container = 24;
 }
 
 // A grant grants permissions

--- a/docs/proposals/container-permissions-and-immutable.md
+++ b/docs/proposals/container-permissions-and-immutable.md
@@ -49,11 +49,15 @@ message ResourcePermissions {
 
   bool delete_container = 21;
   bool move_container = 22;
+  bool set_immutable_file = 23;
+  bool set_immutable_container = 24;
 }
 ```
 
 - `delete_container`: controls whether containers can be deleted, independent of `delete` (which then applies to files only)
 - `move_container`: controls whether containers can be moved/renamed, independent of `move`
+- `set_immutable_file`: controls whether the user may freeze files (irreversible)
+- `set_immutable_container`: controls whether the user may protect/unprotect containers (reversible)
 
 ### Backward compatibility
 

--- a/docs/proposals/container-permissions-and-immutable.md
+++ b/docs/proposals/container-permissions-and-immutable.md
@@ -71,9 +71,11 @@ message ResourceInfo {
 
 This is a **persistent attribute** (stored as xattr on the filesystem), not a transient status. It is returned by `Stat()` and set/cleared via dedicated RPCs.
 
-Semantics:
-- **Files**: cannot be modified, deleted, moved or renamed
-- **Containers**: additionally prevents creation of new children; existing non-immutable children can still be modified
+Semantics — see also [immutable-overview.md](immutable-overview.md):
+
+- **File (freeze)**: the file is final. It cannot be modified (content is fixed), deleted, moved or renamed. Once set on a file, the immutable attribute MUST NOT be removed.
+- **Container (protect)**: no entries can be added, removed or modified. The container itself cannot be deleted, moved or renamed. This does NOT propagate: unprotected children can still be modified. The attribute can be removed by space managers or administrators.
+- **Self vs. parent**: an object is considered immutable if its own attribute is set OR its parent container's attribute is set. Deletion, modification or renaming is governed by the parent; adding or removing entries inside a container by the container itself.
 
 ### RPCs
 

--- a/docs/proposals/container-permissions-and-immutable.md
+++ b/docs/proposals/container-permissions-and-immutable.md
@@ -1,0 +1,137 @@
+# Proposal: Container-Specific Permissions and Immutable Resources
+
+## Status
+
+Draft
+
+## Authors
+
+- @flash7777
+
+## Summary
+
+This proposal adds three new fields to the CS3 storage provider API:
+
+1. **`delete_container`** (ResourcePermissions field 21) — granular delete permission for containers/directories
+2. **`move_container`** (ResourcePermissions field 22) — granular move/rename permission for containers/directories
+3. **`immutable`** (ResourceInfo field 20) — flag to mark a resource as frozen/immutable
+
+## Motivation
+
+### Problem 1: No distinction between file and container operations
+
+The current `ResourcePermissions` message uses a single `delete` flag for both files and containers, and a single `move` flag for both. This makes it impossible to configure a role that allows users to delete files but not directories, or to rename files but not directories.
+
+This is a common requirement in Document Management Systems (DMS), records management, and compliance scenarios where directory structures must be protected while allowing normal file operations within them.
+
+**Real-world example: File plans (Aktenplan)**
+
+In German public administration and corporate environments, a rigid hierarchical directory structure (Aktenplan) must be maintained. Users should be able to add and edit documents within the structure, but must not be able to delete or rename the directories that form the structure.
+
+```
+/01 Administration          <- protected (no delete/rename)
+  /01.01 HR                 <- protected
+    /01.01.01 Recruiting    <- protected
+      /Applications/        <- user can create, edit, delete files here
+        resume.pdf
+        cover_letter.pdf
+```
+
+### Problem 2: No immutability concept
+
+There is no way to mark a resource as immutable/frozen in the CS3 API. Locks exist but serve a different purpose (temporary collaborative editing locks with expiration). Immutability is a permanent (until explicitly removed) state that:
+
+- Prevents modification, deletion, moving, and renaming of the resource
+- For containers: also prevents creation of new children
+- Is typically set by administrators or space managers
+- Supports DMS features like retention, legal hold, and archive states
+
+## Specification
+
+### New fields in ResourcePermissions
+
+```protobuf
+message ResourcePermissions {
+  // ... existing fields 1-20 ...
+
+  // When set, controls whether containers (directories) can be deleted,
+  // independent of the delete permission which then only applies to files.
+  bool delete_container = 21;
+
+  // When set, controls whether containers (directories) can be
+  // moved or renamed, independent of the move permission which
+  // then only applies to files.
+  bool move_container = 22;
+}
+```
+
+### Backward compatibility
+
+When `delete_container` and `move_container` are not explicitly set (default `false` in protobuf), implementations SHOULD fall back to the existing `delete` and `move` permissions for containers. This means:
+
+- Existing clients that don't know about the new fields continue to work unchanged
+- Existing roles that set `delete=true` will still allow container deletion (via fallback)
+- Only when `delete_container` is explicitly managed does the separation take effect
+
+**Recommended implementation logic:**
+
+```
+canDeleteContainer = perm.delete_container OR (perm.delete AND NOT explicitly_managing_container_perms)
+```
+
+### New field in ResourceInfo
+
+```protobuf
+message ResourceInfo {
+  // ... existing fields 1-19 ...
+
+  // When true, the resource is immutable (frozen).
+  bool immutable = 20;
+}
+```
+
+### Immutable semantics
+
+For **files:**
+- Cannot be modified (upload/overwrite denied)
+- Cannot be deleted or moved/renamed
+
+For **containers:**
+- Cannot be deleted or moved/renamed
+- No new children can be created within
+- Existing non-immutable children can still be modified
+- Existing immutable children follow their own immutable rules
+
+### Setting immutable
+
+The `immutable` flag can be set via:
+- `SetArbitraryMetadata` with reserved key `cs3:immutable`
+- Or a dedicated RPC (future extension)
+
+Only users with management permissions (space owner, space manager, administrator) should be able to set or clear the immutable flag.
+
+## ACL representation
+
+For storage backends using ACL strings (e.g., EOS-style):
+
+```
++dc  = delete_container allowed
+!dc  = delete_container denied
++mc  = move_container allowed
+!mc  = move_container denied
+```
+
+## Use cases
+
+1. **File plan (Aktenplan) protection**: Rigid directory structure with free file operations below
+2. **Retention / Legal hold**: Mark resources as immutable during retention periods
+3. **Archive directories**: Freeze completed project folders while keeping them accessible
+4. **Collaborative workspaces**: Allow file operations while preventing accidental directory deletion
+5. **Compliance**: Meet regulatory requirements for records management
+
+## Impact
+
+- **Proto changes**: 3 new fields (backward compatible, additive only)
+- **Storage drivers**: Need to implement container-type checks in delete/move handlers
+- **Gateway**: Needs to pass through new permission fields
+- **Clients**: Can gradually adopt new fields; existing behavior unchanged

--- a/docs/proposals/container-permissions-and-immutable.md
+++ b/docs/proposals/container-permissions-and-immutable.md
@@ -10,23 +10,20 @@ Draft
 
 ## Summary
 
-This proposal adds three new fields to the CS3 storage provider API:
+This proposal adds:
 
-1. **`delete_container`** (ResourcePermissions field 21) — granular delete permission for containers/directories
-2. **`move_container`** (ResourcePermissions field 22) — granular move/rename permission for containers/directories
-3. **`immutable`** (ResourceInfo field 20) — flag to mark a resource as frozen/immutable
+1. **`delete_container`** + **`move_container`** — two new permission fields in `ResourcePermissions` to distinguish file and container operations
+2. **`immutable`** — a persistent attribute on `ResourceInfo` plus `SetImmutable`/`UnsetImmutable` RPCs to freeze resources
 
 ## Motivation
 
 ### Problem 1: No distinction between file and container operations
 
-The current `ResourcePermissions` message uses a single `delete` flag for both files and containers, and a single `move` flag for both. This makes it impossible to configure a role that allows users to delete files but not directories, or to rename files but not directories.
-
-This is a common requirement in Document Management Systems (DMS), records management, and compliance scenarios where directory structures must be protected while allowing normal file operations within them.
+The current `ResourcePermissions` uses a single `delete` flag for both files and containers, and a single `move` flag for both. This makes it impossible to configure a role that allows file deletion but protects directory structures.
 
 **Real-world example: File plans (Aktenplan)**
 
-In German public administration and corporate environments, a rigid hierarchical directory structure (Aktenplan) must be maintained. Users should be able to add and edit documents within the structure, but must not be able to delete or rename the directories that form the structure.
+In German public administration, a rigid hierarchical directory structure (Aktenplan) must be maintained. Users work with documents freely, but must not alter the directory structure.
 
 ```
 /01 Administration          <- protected (no delete/rename)
@@ -34,17 +31,13 @@ In German public administration and corporate environments, a rigid hierarchical
     /01.01.01 Recruiting    <- protected
       /Applications/        <- user can create, edit, delete files here
         resume.pdf
-        cover_letter.pdf
 ```
 
 ### Problem 2: No immutability concept
 
-There is no way to mark a resource as immutable/frozen in the CS3 API. Locks exist but serve a different purpose (temporary collaborative editing locks with expiration). Immutability is a permanent (until explicitly removed) state that:
+Locks are temporary (expiration-based) and designed for collaborative editing. What is missing is a **persistent attribute** on a resource — stored as xattr, returned via `Stat()`, set/unset via dedicated RPCs — that prevents structural changes.
 
-- Prevents modification, deletion, moving, and renaming of the resource
-- For containers: also prevents creation of new children
-- Is typically set by administrators or space managers
-- Supports DMS features like retention, legal hold, and archive states
+This is fundamentally different from a transient processing status (cf. #190). Immutable is a deliberate administrative decision, not a system state.
 
 ## Specification
 
@@ -54,65 +47,65 @@ There is no way to mark a resource as immutable/frozen in the CS3 API. Locks exi
 message ResourcePermissions {
   // ... existing fields 1-20 ...
 
-  // When set, controls whether containers (directories) can be deleted,
-  // independent of the delete permission which then only applies to files.
   bool delete_container = 21;
-
-  // When set, controls whether containers (directories) can be
-  // moved or renamed, independent of the move permission which
-  // then only applies to files.
   bool move_container = 22;
 }
 ```
 
+- `delete_container`: controls whether containers can be deleted, independent of `delete` (which then applies to files only)
+- `move_container`: controls whether containers can be moved/renamed, independent of `move`
+
 ### Backward compatibility
 
-When `delete_container` and `move_container` are not explicitly set (default `false` in protobuf), implementations SHOULD fall back to the existing `delete` and `move` permissions for containers. This means:
+When not explicitly set, implementations SHOULD fall back to `delete`/`move` for containers. Existing clients work unchanged.
 
-- Existing clients that don't know about the new fields continue to work unchanged
-- Existing roles that set `delete=true` will still allow container deletion (via fallback)
-- Only when `delete_container` is explicitly managed does the separation take effect
-
-**Recommended implementation logic:**
-
-```
-canDeleteContainer = perm.delete_container OR (perm.delete AND NOT explicitly_managing_container_perms)
-```
-
-### New field in ResourceInfo
+### Immutable attribute on ResourceInfo
 
 ```protobuf
 message ResourceInfo {
   // ... existing fields 1-19 ...
 
-  // When true, the resource is immutable (frozen).
   bool immutable = 20;
 }
 ```
 
-### Immutable semantics
+This is a **persistent attribute** (stored as xattr on the filesystem), not a transient status. It is returned by `Stat()` and set/cleared via dedicated RPCs.
 
-For **files:**
-- Cannot be modified (upload/overwrite denied)
-- Cannot be deleted or moved/renamed
+Semantics:
+- **Files**: cannot be modified, deleted, moved or renamed
+- **Containers**: additionally prevents creation of new children; existing non-immutable children can still be modified
 
-For **containers:**
-- Cannot be deleted or moved/renamed
-- No new children can be created within
-- Existing non-immutable children can still be modified
-- Existing immutable children follow their own immutable rules
+### RPCs
 
-### Setting immutable
+```protobuf
+rpc SetImmutable(SetImmutableRequest) returns (SetImmutableResponse);
+rpc UnsetImmutable(UnsetImmutableRequest) returns (UnsetImmutableResponse);
+```
 
-The `immutable` flag can be set via:
-- `SetArbitraryMetadata` with reserved key `cs3:immutable`
-- Or a dedicated RPC (future extension)
+Only users with management permissions (space owner, space manager, administrator) may call these RPCs.
 
-Only users with management permissions (space owner, space manager, administrator) should be able to set or clear the immutable flag.
+The pattern follows `SetLock`/`Unlock` — a `Reference` identifies the target resource.
+
+### Distinction: attribute vs. action
+
+| | Attribute (`immutable`) | Action (`SetImmutable` / `UnsetImmutable`) |
+|---|---|---|
+| What | Boolean on the resource, persisted as xattr | RPC to change the attribute |
+| When read | Returned in `ResourceInfo` via `Stat()` | — |
+| Who sets | Manager / Admin via RPC | — |
+| Expiration | None (permanent until explicitly unset) | — |
+
+### Distinction from Locks (#190 Status)
+
+| | Lock | Immutable | Status (#190) |
+|---|---|---|---|
+| Purpose | Collaborative editing | Structure/content protection | Processing state |
+| Duration | Temporary (with expiration) | Permanent (until admin unsets) | Transient |
+| Storage | Lock file / xattr | xattr | Opaque / xattr |
+| Set by | Any user with write access | Manager / Admin only | System / App |
+| Scope | Prevents concurrent writes | Prevents all modifications | Informational |
 
 ## ACL representation
-
-For storage backends using ACL strings (e.g., EOS-style):
 
 ```
 +dc  = delete_container allowed
@@ -123,15 +116,15 @@ For storage backends using ACL strings (e.g., EOS-style):
 
 ## Use cases
 
-1. **File plan (Aktenplan) protection**: Rigid directory structure with free file operations below
-2. **Retention / Legal hold**: Mark resources as immutable during retention periods
-3. **Archive directories**: Freeze completed project folders while keeping them accessible
-4. **Collaborative workspaces**: Allow file operations while preventing accidental directory deletion
-5. **Compliance**: Meet regulatory requirements for records management
+1. **File plan (Aktenplan) protection**: rigid directory structure, free file operations below
+2. **Retention / Legal hold**: freeze resources during retention periods
+3. **Archive directories**: freeze completed project folders
+4. **Collaborative workspaces**: prevent accidental directory deletion
+5. **Compliance**: regulatory requirements for records management
 
 ## Impact
 
-- **Proto changes**: 3 new fields (backward compatible, additive only)
-- **Storage drivers**: Need to implement container-type checks in delete/move handlers
-- **Gateway**: Needs to pass through new permission fields
-- **Clients**: Can gradually adopt new fields; existing behavior unchanged
+- **Proto changes**: 2 new fields in ResourcePermissions, 1 new field in ResourceInfo, 2 new RPCs (all additive, backward compatible)
+- **Storage drivers**: container-type checks in delete/move handlers; xattr for immutable
+- **Gateway**: pass through new fields and RPCs
+- **Clients**: gradual adoption; existing behavior unchanged

--- a/docs/proposals/immutable-overview.md
+++ b/docs/proposals/immutable-overview.md
@@ -7,12 +7,10 @@ on a file it means **freeze**, on a directory it means **protect**.
 
 The file is final:
 
-- No modification (no new revision).
+- No modification (content is fixed).
 - No deletion.
 - No renaming / moving.
-
-Since every change creates a new revision, "no new revision" also means
-"content is fixed".
+- **Irreversible** — once set, the attribute cannot be removed.
 
 ## Directory — protect
 
@@ -22,6 +20,7 @@ the container, not the entries:
 - No entries can be added or removed.
 - No modification of direct entries (files or subdirectories).
 - No renaming / moving / deleting of the directory itself.
+- **Reversible** — space managers or administrators can remove the attribute.
 
 It does **not** propagate to the entries: a protected directory can
 contain an unprotected directory in which entries can still be added,
@@ -30,12 +29,73 @@ removed or modified.
 ## Self vs. parent
 
 An object is immutable if its own attribute is set (self) **or** its
-parent directory's attribute is set (parent). Renaming or deleting an
-object is governed by the parent; adding or removing inside it by the
-object itself.
+parent directory's attribute is set (parent). Renaming, modification
+or deleting an object is governed by the parent; adding or removing
+inside it by the object itself.
+
+## Effective state
+
+Each object has one of three effective states:
+
+| State | Meaning | Icon |
+|-------|---------|------|
+| **Frozen** | Own attribute is set | Shield filled |
+| **Protected** | Parent's attribute is set | Shield outline |
+| **None** | Neither self nor parent | — |
+
+This applies equally to files and directories. A directory inside a
+protected parent is itself Protected — it cannot be deleted or renamed,
+but since it is not itself immutable, entries inside it can be freely
+added, removed or modified.
+
+## Distinction from locks
+
+| | Lock | Immutable |
+|---|---|---|
+| Purpose | Collaborative editing | Structure/content protection |
+| Duration | Temporary (with expiration) | Permanent (files) / until admin removes (dirs) |
+| Set by | Any user with write access | Manager / Admin only |
+| Scope | Prevents parallel writes | Prevents all modifications |
+
+## Permissions
+
+Setting the immutable attribute requires separate permissions for
+files and directories:
+
+- `set_immutable_file` — freeze files (irreversible, grant carefully)
+- `set_immutable_container` — protect/unprotect containers (reversible)
+
+Only Manager and Coowner roles have these permissions by default.
 
 ## Setting
 
-- Single: this object only.
-- Recursive: this object and all descendants (a batch operation; one
-  attribute is still stored per object).
+- **Single**: `SetImmutable` RPC on a single resource reference.
+- **Recursive**: application-level batch operation (e.g. `aktenplan-apply`
+  calling `SetImmutable` per node). One attribute is stored per object.
+  Recursive setting is not part of the CS3 API — it is the caller's
+  responsibility.
+
+## Storage
+
+Persistent as extended attribute `user.oc.immutable` on the filesystem
+node. Returned in `ResourceInfo.Immutable` via `Stat()`. Effective
+state (frozen/protected) transported via `Opaque["immutable-state"]`.
+
+## WebDAV
+
+- `oc:immutable` property: `frozen`, `protected`, or absent
+- `oc:permissions`: `D` (delete) and `NV` (rename/move) flags are
+  stripped when the resource is effectively immutable
+
+## Implementation status
+
+Fully implemented across all layers:
+
+| Layer | Status |
+|-------|--------|
+| CS3 Proto (cs3apis#272) | APPROVED, awaiting merge |
+| Go Bindings (go-cs3apis fork) | Done |
+| Reva decomposedfs | Done, tested (21+ tests) |
+| WebDAV PROPFIND | Done |
+| Graph API (OpenCloud) | Done |
+| Web Frontend | Done |

--- a/docs/proposals/immutable-overview.md
+++ b/docs/proposals/immutable-overview.md
@@ -1,0 +1,41 @@
+# Immutable
+
+One attribute per object. Its effect depends on the object type:
+on a file it means **freeze**, on a directory it means **protect**.
+
+## File — freeze
+
+The file is final:
+
+- No modification (no new revision).
+- No deletion.
+- No renaming / moving.
+
+Since every change creates a new revision, "no new revision" also means
+"content is fixed".
+
+## Directory — protect
+
+A directory is a container, defined by its entries. Protecting it fixes
+the container, not the entries:
+
+- No entries can be added or removed.
+- No modification of direct entries (files or subdirectories).
+- No renaming / moving / deleting of the directory itself.
+
+It does **not** propagate to the entries: a protected directory can
+contain an unprotected directory in which entries can still be added,
+removed or modified.
+
+## Self vs. parent
+
+An object is immutable if its own attribute is set (self) **or** its
+parent directory's attribute is set (parent). Renaming or deleting an
+object is governed by the parent; adding or removing inside it by the
+object itself.
+
+## Setting
+
+- Single: this object only.
+- Recursive: this object and all descendants (a batch operation; one
+  attribute is still stored per object).


### PR DESCRIPTION
## Summary

This PR adds container-specific permissions and an immutable (freeze) attribute to the CS3 storage provider API.

### New fields in `ResourcePermissions`
- **`delete_container`** (field 21): delete permission for containers only, independent of file `delete`
- **`move_container`** (field 22): move/rename permission for containers only, independent of file `move`

### New attribute in `ResourceInfo`
- **`immutable`** (field 20): persistent boolean attribute (xattr) — when true, resource cannot be modified/deleted/moved/renamed. For containers, also prevents creation of new children.

### New RPCs in `ProviderAPI`
- **`SetImmutable`**: freezes a resource (manager/admin only)
- **`UnsetImmutable`**: unfreezes a resource (manager/admin only)

## Motivation

We are developing an EDMS layer for German municipalities on top of OpenCloud/Reva. Core requirement: protecting file plan (Aktenplan) directory structures while allowing users to work freely with documents inside them.

The current API cannot express "users may delete files but not directories" — `delete` and `move` apply to both equally. And there is no persistent freeze/immutable concept (locks are temporary).

See `docs/proposals/container-permissions-and-immutable.md` for the full proposal.

## Note on field 20

Field 20 in `ResourceInfo` is also targeted by #190 (Status). We have commented there to coordinate. We believe `immutable` and `status` serve different purposes (persistent admin attribute vs. transient processing state) and deserve separate fields.

## Backward compatibility

All changes are additive. When new permission fields are not set, implementations fall back to existing `delete`/`move` behavior. Existing clients continue to work unchanged.

## Related

- Reva ACL implementation: cs3org/reva#5628
- Field 20 coordination: #190