### PR TITLE
feat(gateway): add SetImmutable/UnsetImmutable RPCs

### DIFF
--- a/cs3/gateway/v1beta1/gateway_api.proto
+++ b/cs3/gateway/v1beta1/gateway_api.proto
@@ -210,6 +210,13 @@ service GatewayAPI {
   rpc UpdateStorageSpace(cs3.storage.provider.v1beta1.UpdateStorageSpaceRequest) returns (cs3.storage.provider.v1beta1.UpdateStorageSpaceResponse);
   // Deletes a storage space.
   rpc DeleteStorageSpace(cs3.storage.provider.v1beta1.DeleteStorageSpaceRequest) returns (cs3.storage.provider.v1beta1.DeleteStorageSpaceResponse);
+  // Set the immutable attribute on a resource.
+  // Files become frozen (irreversible), containers become protected (reversible).
+  // See cs3org/cs3apis#272 for the specification.
+  rpc SetImmutable(cs3.storage.provider.v1beta1.SetImmutableRequest) returns (cs3.storage.provider.v1beta1.SetImmutableResponse);
+  // Remove the immutable attribute from a resource.
+  // Only applicable to containers (protected). Frozen files cannot be unfrozen.
+  rpc UnsetImmutable(cs3.storage.provider.v1beta1.UnsetImmutableRequest) returns (cs3.storage.provider.v1beta1.UnsetImmutableResponse);
   // *****************************************************************/
   // ************************ APP PROVIDER ********************/
   // *****************************************************************/


### PR DESCRIPTION
## Summary

Follow-up to #272. Exposes `SetImmutable` and `UnsetImmutable` on the Gateway API so that higher-level clients (like the OpenCloud Graph API) can call them through the gateway without needing direct StorageProvider access.

## Changes

- `cs3/gateway/v1beta1/gateway_api.proto`: add `SetImmutable` and `UnsetImmutable` RPCs using the existing request/response types from `cs3.storage.provider.v1beta1`

## Context

#272 added `SetImmutable`/`UnsetImmutable` to the StorageProvider API. The Reva gateway already proxies these calls (server-side), but the gateway proto client interface doesn't expose them yet. This blocks the OpenCloud Graph API from using these RPCs through the standard gateway client.

## Test plan

- [ ] Proto compiles
- [ ] Generated Go code includes new gateway client methods